### PR TITLE
Shebang modification for terry.py

### DIFF
--- a/terry.py
+++ b/terry.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/env python3
 
 import click
 import json


### PR DESCRIPTION
Changed shebang to better support mac and systems with non-standard python installations. The new shebang line will use the system's env to find the correct version of python to use when running terry.