### PR TITLE
Update .htaccess file so that it redirects correctly

### DIFF
--- a/templates/apache2/.htaccess.j2
+++ b/templates/apache2/.htaccess.j2
@@ -13,7 +13,7 @@ RewriteEngine On
 ############ Start Basic Example Redirect Rule ############
 ## Description: Proxy all trafic to the URL below
 
-RewriteRule ^.*$ https://{{ redirect_to }}:443%{REQUEST_URI} [P]
+RewriteRule ^.*$ https://{{ redirect_to }}:1443%{REQUEST_URI} [P]
 
 ############ End Basic Example Redirect Rule ############
 


### PR DESCRIPTION
the `container_mappings_example.yml` maps 443 to 1443, but the redirector redirects to 443, on the wrong side of the container mapping.  When the `.htacces` file is updated to redirect to `$domain:1443`, the redirector and teamserver can communicate and receive beaconing responses. 

The teamserver's firewall rules also reflect this:
```
1443/tcp                   ALLOW       $defined_ip               # Allow 1443/1443 terry
```



`.htaccess ` file after change: 
<img width="449" alt="image" src="https://user-images.githubusercontent.com/32903188/213786634-67bd7d0e-6662-473e-b09b-9c701cab70f5.png">

<img width="772" alt="image" src="https://user-images.githubusercontent.com/32903188/213786758-a1a53a53-a9c9-49b4-80f4-c6db36623bf3.png">


Note: accessing the cobalt strike teamserver is similar, the `container_mappings.yml` defines `1111:50050`, so you need to edit the default client connection from `50050` to `1111` to connect. I assume this was intentional. 


