### PR TITLE
allow specifying environment variables for Docker containers

### DIFF
--- a/templates/docker/docker-compose.yml.j2
+++ b/templates/docker/docker-compose.yml.j2
@@ -18,5 +18,11 @@ services:
       target: "{{ volume.target }}"
 {% endfor %}
 {% endif %}
+{% if 'environment' in service %}
+    environment:
+{% for env in service.environment %}
+    - {{ env }}
+{% endfor %}
+{% endif %}
 
 {% endfor %}


### PR DESCRIPTION
When generating the docker-compose file from the container_mappings, propagate through the environment variables in the "environment" key.