### PR TITLE
show containers in server tables for bare servers

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -754,7 +754,10 @@ def display_resources(ctx):
     
     for resource in ctx.obj['resources']:
         if isinstance(resource, Server):
-            server = [ resource.name, resource.server_type, resource.public_ip, resource.nebula_ip, resource.provider, resource.domain ]
+            server_type = resource.server_type
+            if server_type == "bare" and resource.containers:
+                server_type = "bare ({})".format(",".join(c.name for c in resource.containers))
+            server = [ resource.name, server_type, resource.public_ip, resource.nebula_ip, resource.provider, resource.domain ]
             servers.append(server)
         elif isinstance(resource, Domain):
             for record in resource.domain_records:


### PR DESCRIPTION
When printing out the server table (e.g. with the show command), for bare servers with containers, print out the containers to help differentiate servers.

Before:
```
╒═══════════════════╤═══════════════╤
│ server_name       │ server_type   │
╞═══════════════════╪═══════════════╪
│ curbless-unodious │ bare          │ ...
```

After:
```
╒═══════════════════╤════════════════╤
│ server_name       │ server_type    │
╞═══════════════════╪════════════════╪
│ curbless-unodious │ bare (gophish) │ ...
```